### PR TITLE
npxを使用してpnpmを実行するように修正

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,7 @@ fi
 
 set -eu
 
-pnpm install
+npx pnpm install
 
 if [ -d bin ]; then
   rm -r bin


### PR DESCRIPTION
## 概要
install.shスクリプトで、pnpmをnpx経由で実行するように変更しました。

## 変更内容
- `pnpm install` を `npx pnpm install` に変更

## 変更理由
この変更により、pnpmがグローバルにインストールされていない環境でも、npxを通じてpnpmを実行できるようになります。これにより以下のメリットがあります：

- インストールスクリプトの可搬性が向上
- 開発者のセットアップ要件が削減
- pnpmのグローバルインストール状況に関わらず一貫した実行が可能