### PR TITLE
install.shのshellcheckエラーを修正

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,14 +1,13 @@
 #!/bin/bash
 
-pushd $(dirname ${0}) >/dev/null
+pushd "$(dirname "${0}")" >/dev/null
 BASE_DIR=$(pwd)
 popd >/dev/null
 
-pushd $BASE_DIR >>/dev/null
+pushd "$BASE_DIR" >>/dev/null
 
-type brew >/dev/null
-if [ $? -eq 0 ]; then
-  source $(brew --prefix asdf)/libexec/asdf.sh
+if type brew >/dev/null 2>&1; then
+  source "$(brew --prefix asdf)/libexec/asdf.sh"
 else
   source /opt/asdf/asdf.sh
 fi
@@ -25,8 +24,9 @@ if [ ! -d bin ]; then
   mkdir bin
 fi
 
-for bin_file in $(\ls node_modules/.bin); do
-  cp bin_templ bin/$bin_file
+for bin_file in node_modules/.bin/*; do
+  [ -e "$bin_file" ] || continue
+  cp bin_templ "bin/$(basename "$bin_file")"
 done
 
 popd >>/dev/null


### PR DESCRIPTION
## 概要
install.shスクリプトのshellcheck警告を修正し、スクリプトの安定性を向上させました。

## 変更内容
- コマンド置換と変数を適切にクォート処理
- `$?`を使用した間接的なexit codeチェックから`if type brew`への直接チェックに変更  
- 脆弱な`ls`出力のイテレーションをglobパターンに置き換え

## 変更理由
shellcheckで検出された以下の問題を解決：
- スペースを含むパスでの潜在的な問題
- lsの出力をパースする脆弱な処理
- bashのベストプラクティスに従っていない箇所

## 効果
- スペースを含むパスでのスクリプトの信頼性向上
- より保守しやすく、bashのベストプラクティスに準拠したコード
- shellcheckエラーの解消（情報レベルのSC1091警告を除く）