### PR TITLE
install.sh で asdf install を自動実行するようにする

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -14,6 +14,8 @@ if [ -f /opt/asdf/asdf.sh ]; then
   source /opt/asdf/asdf.sh
 fi
 
+asdf install
+
 set -eu
 
 npx pnpm install


### PR DESCRIPTION
## 概要 / Summary

`install.sh` から `asdf install` を呼び出すようにし、リポジトリで宣言されているツールバージョンを自動でインストールします。

## 変更の背景 / Why

これまでの `install.sh` は `asdf` を source するだけで、必要なツールバージョンのインストールは手動で行う必要がありました。新しい環境でセットアップする際に `asdf install` を忘れると、後続の `pnpm install` が失敗するケースがあります。

## 変更内容 / What

- `asdf` を source した直後に `asdf install` を実行するように追記しました。

## 動作確認 / Testing

- `bash install.sh` を実行し、宣言済みのツールバージョンが自動で導入された上で `pnpm install` が完走することを確認。