### PR TITLE
pnpm に trustPolicy no-downgrade を追加

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,1 +1,3 @@
 minimumReleaseAge: 10080
+trustPolicy: no-downgrade
+


### PR DESCRIPTION
## 概要

`pnpm-workspace.yaml` に `trustPolicy: no-downgrade` を追加しました。

## 変更内容

- `trustPolicy: no-downgrade` を設定し、既にインストールされているパッケージのバージョンがダウングレードされる解決を pnpm が拒否するようにしました。

## 目的

- 意図しないバージョンのリグレッションや、サプライチェーンにおけるダウングレード攻撃を防ぐため。

## レビュアーへの注意点

- 設定変更のみで、依存関係そのものの追加・更新は行っていません。